### PR TITLE
Release Tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,11 @@ jobs:
         run: /snap/bin/ctest --preset=${{ matrix.cc }}-${{ matrix.build_type }}-warnings
 
       - name: Pack
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/r') }}
         run: /snap/bin/cpack --preset=${{ matrix.cc }}-${{ matrix.build_type }}-warnings
 
       - name: Upload
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/r') }}
         uses: actions/upload-artifact@v4
         with:
           path: ./build/${{ matrix.cc }}-${{ matrix.build_type }}-warnings/emulator-0.1.1-Linux.tar.gz
@@ -64,7 +64,7 @@ jobs:
           if-no-files-found: 'error'
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/r') }}
     runs-on: ubuntu-latest
     needs: build
 
@@ -90,7 +90,7 @@ jobs:
           if-no-files-found: 'error'
 
   publish:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/r') }}
     name: "Publish precompiled gcc ${{ matrix.build_type }}"
     runs-on: ubuntu-latest
     needs: release


### PR DESCRIPTION
# Brief

This PR introduces special tags that initiate software releases.

# Details

Currently, push of any tag starting with "v" initiates creating a software package and release. After this PR, such tags will only create packages. Releases are only initiated by pushing tags starting with "r".