### PR TITLE
Memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(emulator_core
     include/ALU.hpp
     include/Clock.hpp
     include/CPU.hpp
+    include/Memory.hpp
     include/Opcode.hpp
     include/StatusRegister.hpp
 
@@ -22,6 +23,7 @@ target_sources(emulator_core
     src/ALU.cpp
     src/Clock.cpp
     src/CPU.cpp
+    src/Memory.cpp
     src/Opcode.cpp
 )
 

--- a/include/CPU.hpp
+++ b/include/CPU.hpp
@@ -5,16 +5,12 @@
 #ifndef EMULATOR_MOS_6502_CPU_HPP
 #define EMULATOR_MOS_6502_CPU_HPP
 #include "Clock.hpp"
+#include "Memory.hpp"
 #include <atomic>
 
 namespace emulator::mos_6502 {
 class CPU {
 public:
-    /**
-     * @brief Alias for the container type that stores memory used by the CPU.
-     */
-    using ROM = std::array<uint8_t, std::numeric_limits<uint16_t>::max()>;
-
     /**
      * @brief Reset vector
      *
@@ -22,7 +18,7 @@ public:
      */
     static constexpr uint16_t RES = 0xFFFC;
 
-    explicit CPU(std::chrono::nanoseconds clock_period, const ROM &rom) noexcept;
+    explicit CPU(std::chrono::nanoseconds clock_period, const Memory &memory) noexcept;
 
     /**
      * @brief Start the CPU
@@ -51,12 +47,12 @@ public:
     /**
      * @brief Get a view of the CPU's memory
      */
-    [[nodiscard]] const ROM &rom() const & noexcept;
+    [[nodiscard]] const Memory &memory() const & noexcept;
 
     /**
      * @brief Get a copy of the CPU's memory
      */
-    [[nodiscard]] ROM rom() const && noexcept;
+    [[nodiscard]] Memory &&memory() && noexcept;
 
 private:
     /**
@@ -105,7 +101,7 @@ private:
     Clock _clock;
 
     /// @brief Memory used by the CPU
-    ROM _rom;
+    Memory _memory;
 
     /// @brief If @p true, the CPU must stop after completing the current operation
     std::atomic_flag _terminate = false;

--- a/include/Memory.hpp
+++ b/include/Memory.hpp
@@ -1,0 +1,130 @@
+//
+// Created by Mikhail Tsaritsyn on Apr 03, 2025.
+//
+
+#ifndef EMULATOR_MOS_6502_MEMORY_HPP
+#define EMULATOR_MOS_6502_MEMORY_HPP
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <unordered_set>
+
+// TODO: Implement Atari 2600 for a 6507 CPU with 8 KB of memory
+
+namespace emulator::mos_6502 {
+/**
+ * @brief A device used as a memory for MOS 6502 CPU.
+ *
+ * Such devices are quite simple. They guarantee to have a value for any 16-bit address.
+ * However, they might be partitioned into read-write (RAM) and read-only (ROM) parts.
+ * Therefore, the value at any address can be read, but an attempt to write into a read-only cell has no effect.
+ * Such values must be set at the object construction.
+ *
+ * Any memory must have the first two pages as RAM for the following purposes:
+ * - 0x0000 to 0x00FF - Zero Page
+ * - 0x0100 to 0x01FF - Stack
+ *
+ * Similarly, any memory must have the following addresses as ROM for the system vectors:
+ * - 0xFFFA to 0xFFFB - Address of non-maskable interrupt handler
+ * - 0xFFFC to 0xFFFD - Initial value of the program counter
+ * - 0xFFFE to 0xFFFF - Address of maskable interrupt handler
+ */
+class Memory {
+public:
+    /**
+     * @brief Underlying container storing the data
+     */
+    using Data = std::array<uint8_t, static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1>;
+
+    /**
+     * @brief Initialize from existing data with minimal partitioning
+     *
+     * Only the system vectors belong to the ROM, all other memory is read-write.
+     */
+    explicit Memory(const Data &data) noexcept;
+
+    /**
+     * @brief Initialize from existing data with a custom partition.
+     *
+     * Partition is defined by a set of masks applied to an address.
+     * If address satisfies any of them, it belongs to the ROM, otherwise to the RAM.
+     * An address satisfies a mask if and only if it contains one at every position where the mask contains one.
+     *
+     * Example: set of masks {0xFFFA, 0xFFFC} only selects the system vectors as ROM.
+     * The fist mask can be written in binary as 0b1111111111111010, so any address smaller than 0b1111111111111000
+     * has at least one zero in a bit where the mask is set.
+     * Addresses between 0xFFF8 and 0xFFFA have a zero where the last set bit of the mask is.
+     *
+     * The second mask is even simpler.
+     * In binary, it is 0b1111111111111100, so any smaller address does not have enough initial ones.
+     */
+    Memory(const Data &data, std::unordered_set<uint16_t> rom_masks) noexcept;
+
+    /**
+     * @brief Partitioning preset for Commodore64 machines.
+     *
+     * @see https://archive.org/details/The_Master_Memory_Map_for_the_Commodore_64
+     *
+     * - 0x0000 to 0x09FF - RAM:
+     *   - 0x0200 to 0x03FF - Used for storing system-related data like screen line links.
+     *   - 0x0400 to 0x07FF - Video Memory to be accessed by VIC-II graphics chip to display text or graphics.
+     *   - 0x0800 to 0x9FFF - General-purpose RAM.
+     * - 0xA000 to 0xBFFF - ROM to store the BASIC interpreter.
+     * - 0xC000 to 0xCFFF - Additional RAM for various purposes.
+     * - 0xD000 to 0xFFFF - ROM:
+     *   - 0xD000 to 0xDFFF - Memory-mapped I/O registers for accessing hardware like the VIC-II (graphics chip),
+     *     SID (sound chip), and CIA (interface adapters).
+     *     Part of this space could also contain the character ROM, which stored font data.
+     *   - 0xE000 to 0xFFFF - The kernel ROM contained essential routines for low-level operations like I/O handling,
+     *     screen display, and interrupt management.
+     */
+    [[nodiscard]] static Memory Commodore64(const Data &data) noexcept;
+
+    /**
+     * @brief Partitioning preset for Apple II machines.
+     *
+     * @see https://archive.org/details/understanding_the_apple_ii
+     *
+     * - 0x0000 to 0xBFFF - RAM:
+     *   - 0x0200 to 0x02FF - Keyboard buffer to store characters typed on the keyboard before processing.
+     *   - 0x0300 to 0x03FF - User area available for short machine language programs or temporary storage.
+     *   - 0x0400 to 0x07FF - Text screen memory used for displaying text on the screen.
+     *   - 0x0800 to 0x1FFF - Applesoft BASIC containing the Applesoft BASIC interpreter,
+     *     which allows users to write and execute BASIC programs.
+     *   - 0x2000 to 0x3FFF - High-resolution graphics page 1.
+     *   - 0x4000 to 0x5FFF - High-resolution graphics page 2.
+     *   - 0x6000 to 0xBFFF - General-purpose RAM for user programs and data.
+     * - 0xC000 to 0xFFFF - ROM:
+     *   - 0xC000 to 0xCFFF - Memory-mapped I/O for interfacing with hardware like disk drives, printers,
+     *     and expansion cards.
+     *   - 0xD000 to 0xFFFF - Contains the system firmware, including Integer BASIC, the monitor program,
+     *     and other essential routines.
+     */
+    [[nodiscard]] static Memory AppleII(const Data &data) noexcept;
+
+    /**
+     * @brief Read a value at a given address
+     */
+    [[nodiscard]] uint8_t operator[](uint16_t address) const noexcept;
+
+    /**
+     * @brief Write a value to a given address.
+     *
+     * If the address belongs to ROM, the operation has no effect.
+     *
+     * @retval true If the write operation succeeded.
+     * @retval false If and only if the address lies within the ROM.
+     */
+    bool write(uint16_t address, uint8_t value) noexcept;
+
+private:
+    [[nodiscard]] bool within_rom(uint16_t address) const noexcept;
+
+    Data _data; ///< Encapsulated data
+
+    std::unordered_set<uint16_t> _rom_masks = { 0xFFFA, 0xFFFC }; ///< Masks defining read-only addresses
+};
+
+} // namespace emulator::mos_6502
+
+#endif //EMULATOR_MOS_6502_MEMORY_HPP

--- a/main.cpp
+++ b/main.cpp
@@ -4,9 +4,9 @@
 #include <thread>
 
 void emulate(const std::chrono::nanoseconds clock_period, const std::chrono::nanoseconds time) {
-    emulator::mos_6502::CPU::ROM rom{};
-    std::ranges::fill(rom, 0);
-    emulator::mos_6502::CPU cpu{ clock_period, rom }; // executes as fast as it can
+    emulator::mos_6502::Memory::Data data{};
+    std::ranges::fill(data, 0);
+    emulator::mos_6502::CPU cpu{ clock_period, emulator::mos_6502::Memory{ data } }; // executes as fast as it can
 
     std::jthread thread{ [&cpu] { cpu.start(); } };
     std::this_thread::sleep_for(time);

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,9 @@
 #include <thread>
 
 void emulate(const std::chrono::nanoseconds clock_period, const std::chrono::nanoseconds time) {
-    emulator::mos_6502::CPU cpu{ clock_period }; // executes as fast as it can
+    emulator::mos_6502::CPU::ROM rom{};
+    std::ranges::fill(rom, 0);
+    emulator::mos_6502::CPU cpu{ clock_period, rom }; // executes as fast as it can
 
     std::jthread thread{ [&cpu] { cpu.start(); } };
     std::this_thread::sleep_for(time);

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -2,12 +2,13 @@
 // Created by Mikhail Tsaritsyn on Apr 02, 2025.
 //
 #include "CPU.hpp"
-
 #include <chrono>
 
 namespace emulator::mos_6502 {
 
-CPU::CPU(const std::chrono::nanoseconds clock_period, const ROM &rom) noexcept : _clock(clock_period), _rom(rom) {}
+CPU::CPU(const std::chrono::nanoseconds clock_period, const Memory &memory) noexcept
+        : _clock(clock_period),
+          _memory(memory) {}
 
 void CPU::start() noexcept {
     reset();
@@ -38,9 +39,9 @@ void CPU::terminate() noexcept { _terminate.test_and_set(); }
 
 double CPU::frequency() const noexcept { return _frequency; }
 
-const CPU::ROM &CPU::rom() const & noexcept { return _rom; }
+const Memory &CPU::memory() const & noexcept { return _memory; }
 
-CPU::ROM CPU::rom() const && noexcept { return _rom; }
+Memory &&CPU::memory() && noexcept { return std::move(_memory); }
 
 uint16_t CPU::make_word(const uint8_t high, const uint8_t low) noexcept {
     return static_cast<uint16_t>(high) << 8 | static_cast<uint16_t>(low);
@@ -60,6 +61,6 @@ void CPU::reset() noexcept {
 uint8_t CPU::read(const uint16_t address) noexcept {
     while (!_clock.value()) {} // wait for the next clock pulse
     _cycle++;
-    return _rom[address];
+    return _memory[address];
 }
 } // namespace emulator::mos_6502

--- a/src/CPU.cpp
+++ b/src/CPU.cpp
@@ -7,16 +7,18 @@
 
 namespace emulator::mos_6502 {
 
-CPU::CPU(const std::chrono::nanoseconds clock_period) noexcept : _clock(clock_period) {}
+CPU::CPU(const std::chrono::nanoseconds clock_period, const ROM &rom) noexcept : _clock(clock_period), _rom(rom) {}
 
 void CPU::start() noexcept {
+    reset();
+
     auto prev_time = std::chrono::high_resolution_clock::now();
     static constexpr size_t window = 100;
     while (!_terminate.test()) {
-        wait_for_clock();
-        _cycle++;
+        read(PC++);
 
         // Estimate the clock frequency using the last 100 pulses
+        // TODO: Move to a separate function?
         if (_cycle % window == 0) {
             const auto current_time                     = std::chrono::high_resolution_clock::now();
             const std::chrono::duration<double> delta_t = current_time - prev_time;
@@ -36,5 +38,28 @@ void CPU::terminate() noexcept { _terminate.test_and_set(); }
 
 double CPU::frequency() const noexcept { return _frequency; }
 
-void CPU::wait_for_clock() noexcept { while (!_clock.value()); }
+const CPU::ROM &CPU::rom() const & noexcept { return _rom; }
+
+CPU::ROM CPU::rom() const && noexcept { return _rom; }
+
+uint16_t CPU::make_word(const uint8_t high, const uint8_t low) noexcept {
+    return static_cast<uint16_t>(high) << 8 | static_cast<uint16_t>(low);
+}
+
+void CPU::reset() noexcept {
+    read(PC++);
+    read(PC++);
+    read(0x0100 + SP);
+    read(0x0100 + SP - 1);
+    read(0x0100 + SP - 2);
+    const auto pcl = read(RES);
+    const auto pch = read(RES + 1);
+    PC             = make_word(pch, pcl);
+}
+
+uint8_t CPU::read(const uint16_t address) noexcept {
+    while (!_clock.value()) {} // wait for the next clock pulse
+    _cycle++;
+    return _rom[address];
+}
 } // namespace emulator::mos_6502

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -1,0 +1,32 @@
+//
+// Created by Mikhail Tsaritsyn on Apr 03, 2025.
+//
+
+#include "Memory.hpp"
+
+#include <algorithm>
+
+namespace emulator::mos_6502 {
+Memory::Memory(const Data &data) noexcept : _data(data) {}
+
+Memory::Memory(const Data &data, std::unordered_set<uint16_t> rom_masks) noexcept
+        : _data(data),
+          _rom_masks(std::move(rom_masks)) {}
+
+Memory Memory::Commodore64(const Data &data) noexcept { return { data, { 0xA000, 0xD000 } }; }
+
+Memory Memory::AppleII(const Data &data) noexcept { return { data, {0xC000} };
+}
+
+uint8_t Memory::operator[](const uint16_t address) const noexcept { return _data[address]; }
+
+bool Memory::write(const uint16_t address, const uint8_t value) noexcept {
+    if (within_rom(address)) return false;
+    _data[address] = value;
+    return true;
+}
+
+bool Memory::within_rom(const uint16_t address) const noexcept {
+    return std::ranges::any_of(_rom_masks, [address](const uint16_t mask) { return (address & mask) == mask; });
+}
+} // namespace emulator::mos_6502


### PR DESCRIPTION
# Brief

This PR implements memory for the CPU to work with

# Details

MOS 6502 CPU has 16-bit addressing, so the memory is guaranteed to accept any 16-bit address. It can be partitioned onto read-only and read-write parts, with operation of writing into the former having no effect.

To support that, a wrapper around std::array of bytes was created. It keeps track of read-only addresses with the help of masks, allowing for flexible custom partitioning. It has a few presets for the easy usage. One defines as little ROM as possible, the other two correspond to real examples of hardware.